### PR TITLE
Add AST structures to testdata

### DIFF
--- a/testdata/basic.c
+++ b/testdata/basic.c
@@ -1,57 +1,67 @@
 #include "testdata.h"
-#include "ast.h"
 
-t_testdata ls(){
-  char *argv[] = {"ls", NULL};
-  t_testdata d_ls = {
-      .input      = "ls",
-      .token_list = NULL,
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = 1,
-            .commands = &(t_command){
-              .type = CMD_SIMPLE,
-              .redirs = NULL,
-              .redir_count = 0,
-              .u.simple = {
-                .argc = 1,
-                .argv = argv,
-                .token_list = NULL
-              }
-            }
-          }
+// Basic command execution
+
+t_testdata ls(void)
+{
+    static char *argv[] = {"ls", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 1
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
         },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls;
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "ls",
+        .token_list = {0},
+        .ast = ast
+    };
 }
 
-
-t_testdata echo_fire(){
-  char *argv[] = {"echo", "fire",NULL};
-  t_testdata d_echo_fire = {
-      .input      = "echo fire",
-      .token_list = NULL,
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = 1,
-            .commands = &(t_command){
-              .type = CMD_SIMPLE,
-              .redirs = NULL,
-              .redir_count = 0,
-              .u.simple = {
-                .argc = 1,
-                .argv = argv,
-                .token_list = NULL
-              }
-            }
-          }
+t_testdata echo_hello(void)
+{
+    static char *argv[] = {"echo", "hello", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 2
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
         },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_echo_fire;
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "echo hello",
+        .token_list = {0},
+        .ast = ast
+    };
 }

--- a/testdata/buildin.c
+++ b/testdata/buildin.c
@@ -1,7 +1,186 @@
-/* ◦ echo with option -n */
-/* ◦ cd with only a relative or absolute path */
-/* ◦ pwd with no options */
-/* ◦ export with no options */
-/* ◦ unset with no options */
-/* ◦ env with no options or arguments */
-/* ◦ exit with no options */
+#include "testdata.h"
+
+// Builtin command edge cases
+
+t_testdata cd_noarg(void)
+{
+    static char *argv[] = {"cd", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 1
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "cd",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata cd_non_existing_dir(void)
+{
+    static char *argv[] = {"cd", "non_existing_dir", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 2
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "cd non_existing_dir",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata export_two_vars(void)
+{
+    static char *argv[] = {"export", "VAR1=hello", "VAR2=world", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 3
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "export VAR1=hello VAR2=world",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata unset_then_echo(void)
+{
+    static char *argv1[] = {"unset", "VAR1", NULL};
+    static t_command cmd1 = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv1,
+            .argc = 2
+        }
+    };
+    static char *argv2[] = {"echo", "$VAR1", NULL};
+    static t_command cmd2 = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv2,
+            .argc = 2
+        }
+    };
+    static t_and_or and_or1 = {
+        .pipeline = {
+            .commands = &cmd1,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_and_or and_or2 = {
+        .pipeline = {
+            .commands = &cmd2,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_list list2 = {
+        .first_and_or = &and_or2,
+        .next = NULL
+    };
+    static t_list list1 = {
+        .first_and_or = &and_or1,
+        .next = &list2
+    };
+    return (t_testdata){
+        .input = "unset VAR1 ; echo $VAR1",
+        .token_list = {0},
+        .ast = list1
+    };
+}
+
+t_testdata exit_status_42(void)
+{
+    static char *argv[] = {"exit", "42", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 2
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = &cmd,
+            .cmd_count = 1
+        },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = {
+        .first_and_or = &and_or,
+        .next = NULL
+    };
+    return (t_testdata){
+        .input = "exit 42",
+        .token_list = {0},
+        .ast = ast
+    };
+}

--- a/testdata/pipe.c
+++ b/testdata/pipe.c
@@ -1,86 +1,106 @@
 #include "testdata.h"
-#include "ast.h"
 
-t_testdata ls_pipe_grep(){
-  char *ls_argv[] = {"ls", NULL};
-  int ls_argc = 1;
-  char *grep_argv[] = {"grep", ".c", NULL};
-  int grep_argc = 2;
-  t_command cmds[] = {
-    {
-      .type = CMD_SIMPLE,
-      .redirs = NULL,
-      .redir_count = 0,
-      .u.simple = {.argc = ls_argc, .argv = ls_argv}
-    },
-    {
-      .type = CMD_SIMPLE,
-      .redirs = NULL,
-      .redir_count = 0,
-      .u.simple = {.argc = grep_argc, .argv = grep_argv}
-    },
-    NULL
-  };
-  int cmd_count = 2;
-  t_testdata d_ls_pipe_grep = {
-      .input      = "ls | grep .c",
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = cmd_count,
-            .commands = cmds
-          }
+// Pipe related commands
+
+t_testdata ls_pipe_grep(void)
+{
+    static char *argv1[] = {"ls", NULL};
+    static char *argv2[] = {"grep", ".c", NULL};
+    static t_command cmds[] = {
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv1, .argc = 1 }
         },
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv2, .argc = 2 }
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = {
+            .commands = cmds,
+            .cmd_count = 2
+        },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls_pipe_grep;
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "ls | grep .c",
+        .token_list = {0},
+        .ast = ast
+    };
 }
 
-
-t_testdata ls_pipe_grep_pipe_wc(){
-
-  char *ls_argv[] = {"ls", NULL};
-  int ls_argc = 1;
-  char *grep_argv[] = {"grep", ".h", NULL};
-  int grep_argc = 2;
-  char *wl_argv[] = {"wl", "-l", NULL};
-  int wl_argc = 2;
-  t_command cmds[] = {
-    {
-      .type = CMD_SIMPLE,
-      .redirs = NULL,
-      .redir_count = 0,
-      .u.simple = {.argc = ls_argc, .argv = ls_argv}
-    },
-    {
-      .type = CMD_SIMPLE,
-      .redirs = NULL,
-      .redir_count = 0,
-      .u.simple = {.argc = grep_argc, .argv = grep_argv}
-    },
-    {
-      .type = CMD_SIMPLE,
-      .redirs = NULL,
-      .redir_count = 0,
-      .u.simple = {.argc = wl_argc, .argv = wl_argv}
-    },
-    NULL
-  };
-  int cmd_count = 3;
-  t_testdata d_ls_pipe_grep_pipe_wc = {
-      .input      = "ls | grep .h | wc -l",
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = cmd_count,
-            .commands = cmds
-          }
+t_testdata cat_makefile_pipe_wc_l(void)
+{
+    static char *argv1[] = {"cat", "Makefile", NULL};
+    static char *argv2[] = {"wc", "-l", NULL};
+    static t_command cmds[] = {
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv1, .argc = 2 }
         },
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv2, .argc = 2 }
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = cmds, .cmd_count = 2 },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls_pipe_grep_pipe_wc;
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "cat Makefile | wc -l",
+        .token_list = {0},
+        .ast = ast
+    };
 }
 
-
+t_testdata ls_pipe_grep_pipe_wc(void)
+{
+    static char *argv1[] = {"ls", NULL};
+    static char *argv2[] = {"grep", ".h", NULL};
+    static char *argv3[] = {"wc", "-l", NULL};
+    static t_command cmds[] = {
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv1, .argc = 1 }
+        },
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv2, .argc = 2 }
+        },
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv3, .argc = 2 }
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = cmds, .cmd_count = 3 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "ls | grep .h | wc -l",
+        .token_list = {0},
+        .ast = ast
+    };
+}

--- a/testdata/quote_and_env.c
+++ b/testdata/quote_and_env.c
@@ -1,0 +1,130 @@
+#include "testdata.h"
+
+// Quote and environment variable handling
+
+t_testdata echo_env_home(void)
+{
+    static char *argv[] = {"echo", "$HOME", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = {
+            .token_list = NULL,
+            .argv = argv,
+            .argc = 2
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo \"$HOME\"",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata echo_no_expand_home(void)
+{
+    static char *argv[] = {"echo", "$HOME", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 2 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo '$HOME'",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata echo_concat_user(void)
+{
+    static char *argv[] = {"echo", "hello'$USER'world", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 2 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo hello'$USER'world",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata export_and_echo(void)
+{
+    static char *argv1[] = {"export", "VAR=test", NULL};
+    static char *argv2[] = {"echo", "$VAR", NULL};
+    static t_command cmd1 = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = { .token_list = NULL, .argv = argv1, .argc = 2 }
+    };
+    static t_command cmd2 = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = { .token_list = NULL, .argv = argv2, .argc = 2 }
+    };
+    static t_and_or and_or1 = {
+        .pipeline = { .commands = &cmd1, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_and_or and_or2 = {
+        .pipeline = { .commands = &cmd2, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_list list2 = { .first_and_or = &and_or2, .next = NULL };
+    static t_list list1 = { .first_and_or = &and_or1, .next = &list2 };
+    return (t_testdata){
+        .input = "export VAR=test ; echo $VAR",
+        .token_list = {0},
+        .ast = list1
+    };
+}
+
+t_testdata echo_status(void)
+{
+    static char *argv[] = {"echo", "$?", NULL};
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = NULL,
+        .redir_count = 0,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 2 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo $?",
+        .token_list = {0},
+        .ast = ast
+    };
+}

--- a/testdata/redirect.c
+++ b/testdata/redirect.c
@@ -1,93 +1,132 @@
 #include "testdata.h"
-#include "ast.h"
 
-t_testdata redir_output (){
-  char *echo_hello_argv[] = {"echo", "hello",NULL};
-  int echo_hello_argc = 2;
-  t_redir redirs[] = {{.type = REDIR_OUTPUT, .target = "out.txt"},NULL};
-  t_command cmds[] = {
-    {
-      .type = CMD_SIMPLE,
-      .redirs = redirs,
-      .redir_count = 1,
-      .u.simple = {.argc = echo_hello_argc, .argv = echo_hello_argv}
-    },
-    NULL
-  };
-  int cmd_count = 1;
-  t_testdata d_ls_pipe_grep = {
-      .input      = "echo hello > out.txt",
-      .token_list = NULL,
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = cmd_count,
-            .commands = cmds
-          }
-        },
+// Redirection examples
+
+t_testdata redir_output(void)
+{
+    static char *argv[] = {"echo", "hello", NULL};
+    static t_redir redirs[] = {
+        { .type = REDIR_OUTPUT, .target = "out.txt" }
+    };
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = redirs,
+        .redir_count = 1,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 2 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls_pipe_grep;
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo hello > out.txt",
+        .token_list = {0},
+        .ast = ast
+    };
 }
 
-
-t_testdata redir_input (){
-  char *cat_argv[] = {"cat",NULL};
-  int cat_argc = 1;
-  t_redir redirs[] = {{.type = REDIR_INPUT, .target = "out.txt"},NULL};
-  t_command cmds[] = {
-    {
-      .type = CMD_SIMPLE,
-      .redirs = redirs,
-      .redir_count = 1,
-      .u.simple = {.argc = cat_argc, .argv = cat_argv}
-    },
-    NULL
-  };
-  int cmd_count = 1;
-  t_testdata d_ls_pipe_grep = {
-      .input      = "cat < out.txt",
-      .token_list = NULL,
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = cmd_count,
-            .commands = cmds
-          }
-        },
+t_testdata redir_input(void)
+{
+    static char *argv[] = {"cat", NULL};
+    static t_redir redirs[] = { { .type = REDIR_INPUT, .target = "out.txt" } };
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = redirs,
+        .redir_count = 1,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 1 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls_pipe_grep;
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "cat < out.txt",
+        .token_list = {0},
+        .ast = ast
+    };
 }
 
-t_testdata redir_append (){
-  char *cat_argv[] = {"cat",NULL};
-  int cat_argc = 1;
-  t_redir redirs[] = {{.type = REDIR_INPUT, .target = "out.txt"},NULL};
-  t_command cmds[] = {
-    {
-      .type = CMD_SIMPLE,
-      .redirs = redirs,
-      .redir_count = 1,
-      .u.simple = {.argc = cat_argc, .argv = cat_argv}
-    },
-    NULL
-  };
-  int cmd_count = 1;
-  t_testdata d_ls_pipe_grep = {
-      .input      = "cat < out.txt",
-      .token_list = NULL,
-      .ast        = {
-        .first_and_or = &(t_and_or){
-          .pipeline = {
-            .cmd_count = cmd_count,
-            .commands = cmds
-          }
-        },
+t_testdata redir_append(void)
+{
+    static char *argv[] = {"echo", "bye", NULL};
+    static t_redir redirs[] = { { .type = REDIR_APPEND, .target = "out.txt" } };
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = redirs,
+        .redir_count = 1,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 2 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
         .next = NULL
-      }
-  };
-  return d_ls_pipe_grep;
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo bye >> out.txt",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata redir_mix(void)
+{
+    static char *argv[] = {"cat", NULL};
+    static t_redir redirs[] = {
+        { .type = REDIR_INPUT, .target = "out.txt" },
+        { .type = REDIR_OUTPUT, .target = "new.txt" }
+    };
+    static t_command cmd = {
+        .type = CMD_SIMPLE,
+        .redirs = redirs,
+        .redir_count = 2,
+        .u.simple = { .token_list = NULL, .argv = argv, .argc = 1 }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = &cmd, .cmd_count = 1 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "cat < out.txt > new.txt",
+        .token_list = {0},
+        .ast = ast
+    };
+}
+
+t_testdata pipe_to_redir(void)
+{
+    static char *argv1[] = {"echo", "test", NULL};
+    static char *argv2[] = {"cat", NULL};
+    static t_redir redirs2[] = { { .type = REDIR_OUTPUT, .target = "result.txt" } };
+    static t_command cmds[] = {
+        {
+            .type = CMD_SIMPLE,
+            .redirs = NULL,
+            .redir_count = 0,
+            .u.simple = { .token_list = NULL, .argv = argv1, .argc = 2 }
+        },
+        {
+            .type = CMD_SIMPLE,
+            .redirs = redirs2,
+            .redir_count = 1,
+            .u.simple = { .token_list = NULL, .argv = argv2, .argc = 1 }
+        }
+    };
+    static t_and_or and_or = {
+        .pipeline = { .commands = cmds, .cmd_count = 2 },
+        .op_next = OP_NONE,
+        .next = NULL
+    };
+    static t_ast ast = { .first_and_or = &and_or, .next = NULL };
+    return (t_testdata){
+        .input = "echo test | cat > result.txt",
+        .token_list = {0},
+        .ast = ast
+    };
 }

--- a/testdata/syntax_error.c
+++ b/testdata/syntax_error.c
@@ -1,0 +1,39 @@
+#include "testdata.h"
+
+// Syntax error cases
+
+t_testdata err_unclosed_quote(void)
+{
+    return (t_testdata){
+        .input = "echo \"unclosed",
+        .token_list = {0},
+        .ast = {0}
+    };
+}
+
+t_testdata err_bad_redir(void)
+{
+    return (t_testdata){
+        .input = "cat <",
+        .token_list = {0},
+        .ast = {0}
+    };
+}
+
+t_testdata err_pipe_position(void)
+{
+    return (t_testdata){
+        .input = "| ls",
+        .token_list = {0},
+        .ast = {0}
+    };
+}
+
+t_testdata err_single_redirect(void)
+{
+    return (t_testdata){
+        .input = ">",
+        .token_list = {0},
+        .ast = {0}
+    };
+}

--- a/testdata/testdata.h
+++ b/testdata/testdata.h
@@ -10,9 +10,40 @@ typedef struct s_testdata {
 } t_testdata;
 
 
-t_testdata ls();
-t_testdata echo_fire();
-t_testdata ls_pipe_grep();
-t_testdata ls_pipe_grep_pipe_wc();
+// basic
+t_testdata ls(void);
+t_testdata echo_hello(void);
+
+// builtin edge cases
+t_testdata cd_noarg(void);
+t_testdata cd_non_existing_dir(void);
+t_testdata export_two_vars(void);
+t_testdata unset_then_echo(void);
+t_testdata exit_status_42(void);
+
+// pipe
+t_testdata ls_pipe_grep(void);
+t_testdata cat_makefile_pipe_wc_l(void);
+t_testdata ls_pipe_grep_pipe_wc(void);
+
+// quote and env
+t_testdata echo_env_home(void);
+t_testdata echo_no_expand_home(void);
+t_testdata echo_concat_user(void);
+t_testdata export_and_echo(void);
+t_testdata echo_status(void);
+
+// redirect
+t_testdata redir_output(void);
+t_testdata redir_input(void);
+t_testdata redir_append(void);
+t_testdata redir_mix(void);
+t_testdata pipe_to_redir(void);
+
+// syntax error
+t_testdata err_unclosed_quote(void);
+t_testdata err_bad_redir(void);
+t_testdata err_pipe_position(void);
+t_testdata err_single_redirect(void);
 
 #endif // !TESTDATA_H


### PR DESCRIPTION
## Summary
- flesh out AST in basic, builtin, pipe, quote/env, and redirect test data
- keep syntax error cases empty

## Testing
- `make testdata`
- `make executor_test` *(fails: tokenizer WIP)*

------
https://chatgpt.com/codex/tasks/task_e_6840085c70088329be468b2977057b5a