### PR TITLE
Add token lists for test data

### DIFF
--- a/testdata/basic.c
+++ b/testdata/basic.c
@@ -27,6 +27,11 @@ t_testdata ls(void) {
 }
 
 t_testdata echo_hello(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "hello", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "hello", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -40,12 +45,17 @@ t_testdata echo_hello(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo hello",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata cat_nofile(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "nofile", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"cat", "nofile", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -60,7 +70,7 @@ t_testdata cat_nofile(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "cat nofile",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }

--- a/testdata/builtin.c
+++ b/testdata/builtin.c
@@ -2,6 +2,9 @@
 
 // Builtin command edge cases
 t_testdata pwd(void) {
+  // TOKEN LIST
+  static t_token_content token = {.value = "pwd", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list = {.content = (void *)&token, .next = NULL};
   static char *argv[] = {"pwd", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -16,10 +19,13 @@ t_testdata pwd(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){
-      .input = "pwd", .token_list = {0}, .ast = ast, .output_file = NULL};
+      .input = "pwd", .token_list = token_list, .ast = ast, .output_file = NULL};
 }
 
 t_testdata cd_noarg(void) {
+  // TOKEN LIST
+  static t_token_content token = {.value = "cd", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list = {.content = (void *)&token, .next = NULL};
   static char *argv[] = {"cd", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -34,10 +40,15 @@ t_testdata cd_noarg(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){
-      .input = "cd", .token_list = {0}, .ast = ast, .output_file = NULL};
+      .input = "cd", .token_list = token_list, .ast = ast, .output_file = NULL};
 }
 
 t_testdata cd_non_existing_dir(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "cd", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "non_existing_dir", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"cd", "non_existing_dir", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -53,12 +64,19 @@ t_testdata cd_non_existing_dir(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "cd non_existing_dir",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata export_two_vars(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "export", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "VAR1=hello", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = "VAR2=world", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"export", "VAR1=hello", "VAR2=world", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -74,12 +92,23 @@ t_testdata export_two_vars(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "export VAR1=hello VAR2=world",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata unset_then_echo(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "unset", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "VAR1", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = ";", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token4 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token5 = {.value = "$VAR1", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"unset", "VAR1", NULL};
   static t_command cmd1 = {
       .type = CMD_SIMPLE,
@@ -108,12 +137,17 @@ t_testdata unset_then_echo(void) {
   static t_ast list2 = {.content = (void *)&and_or2, .next = NULL};
   static t_ast list1 = {.content = (void *)&and_or1, .next = &list2};
   return (t_testdata){.input = "unset VAR1 ; echo $VAR1",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = list1,
                       .output_file = NULL};
 }
 
 t_testdata exit_status_42(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "exit", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "42", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"exit", "42", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -129,5 +163,5 @@ t_testdata exit_status_42(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){
-      .input = "exit 42", .token_list = {0}, .ast = ast, .output_file = NULL};
+      .input = "exit 42", .token_list = token_list1, .ast = ast, .output_file = NULL};
 }

--- a/testdata/pipe.c
+++ b/testdata/pipe.c
@@ -3,6 +3,15 @@
 // Pipe related commands
 
 t_testdata ls_pipe_grep(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "ls", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "|", .type = TOKEN_PIPE};
+  static t_token_content token3 = {.value = "grep", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token4 = {.value = ".c", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"ls", NULL};
   static char *argv2[] = {"grep", ".c", NULL};
 
@@ -27,12 +36,23 @@ t_testdata ls_pipe_grep(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "ls | grep .c",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata cat_makefile_pipe_wc_l(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "Makefile", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = "|", .type = TOKEN_PIPE};
+  static t_token_content token4 = {.value = "wc", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token5 = {.value = "-l", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"cat", "Makefile", NULL};
   static char *argv2[] = {"wc", "-l", NULL};
   static t_command cmd2 = {
@@ -57,12 +77,27 @@ t_testdata cat_makefile_pipe_wc_l(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "cat Makefile | wc -l",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata ls_pipe_grep_pipe_wc(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "ls", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "|", .type = TOKEN_PIPE};
+  static t_token_content token3 = {.value = "grep", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token4 = {.value = ".h", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token5 = {.value = "|", .type = TOKEN_PIPE};
+  static t_token_content token6 = {.value = "wc", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token7 = {.value = "-l", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list7 = {.content = (void *)&token7, .next = NULL};
+  static t_list token_list6 = {.content = (void *)&token6, .next = &token_list7};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"ls", NULL};
   static char *argv2[] = {"grep", ".h", NULL};
   static char *argv3[] = {"wc", "-l", NULL};
@@ -98,7 +133,7 @@ t_testdata ls_pipe_grep_pipe_wc(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "ls | grep .h | wc -l",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }

--- a/testdata/quote_and_env.c
+++ b/testdata/quote_and_env.c
@@ -3,6 +3,11 @@
 // Quote and environment variable handling
 
 t_testdata echo_env_home(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "$HOME", .type = TOKEN_DOUBLE_QUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "$HOME", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -15,12 +20,17 @@ t_testdata echo_env_home(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo \"$HOME\"",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata echo_no_expand_home(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "$HOME", .type = TOKEN_SINGLE_QUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "$HOME", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -34,12 +44,17 @@ t_testdata echo_no_expand_home(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo '$HOME'",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata echo_concat_user(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "hello'$USER'world", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "hello'$USER'world", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -53,12 +68,23 @@ t_testdata echo_concat_user(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo hello'$USER'world",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = NULL};
 }
 
 t_testdata export_and_echo(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "export", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "VAR=test", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = ";", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token4 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token5 = {.value = "$VAR", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"export", "VAR=test", NULL};
   static char *argv2[] = {"echo", "$VAR", NULL};
   static t_command cmd1 = {
@@ -85,10 +111,15 @@ t_testdata export_and_echo(void) {
   static t_ast list2 = {.content = (void *)&and_or2, .next = NULL};
   static t_ast list1 = {.content = (void *)&and_or1, .next = &list2};
   return (t_testdata){
-      .input = "export VAR=test ; echo $VAR", .token_list = {0}, .ast = list1};
+      .input = "export VAR=test ; echo $VAR", .token_list = token_list1, .ast = list1};
 }
 
 t_testdata echo_status(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "$?", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "$?", NULL};
   static t_command cmd = {
       .type = CMD_SIMPLE,
@@ -102,5 +133,5 @@ t_testdata echo_status(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){
-      .input = "echo $?", .token_list = {0}, .ast = ast, .output_file = NULL};
+      .input = "echo $?", .token_list = token_list1, .ast = ast, .output_file = NULL};
 }

--- a/testdata/redirect.c
+++ b/testdata/redirect.c
@@ -9,6 +9,15 @@
 /* .filename = NULL, */
 /* .filename_token = NULL, */
 t_testdata redir_output(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "hello", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
+  static t_token_content token4 = {.value = "out.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "hello", NULL};
   static t_redir redir = {.type = REDIR_OUTPUT,
                           .from =
@@ -37,12 +46,19 @@ t_testdata redir_output(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo hello > out.txt",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = "out.txt"};
 }
 
 t_testdata redir_input(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "<", .type = TOKEN_REDIR_INPUT};
+  static t_token_content token3 = {.value = "out.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"cat", NULL};
   static t_redir redir = {.type = REDIR_INPUT,
                           .from =
@@ -70,10 +86,19 @@ t_testdata redir_input(void) {
       .op_next = OP_NONE,
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
-  return (t_testdata){.input = "cat < out.txt", .token_list = {0}, .ast = ast};
+  return (t_testdata){.input = "cat < out.txt", .token_list = token_list1, .ast = ast};
 }
 
 t_testdata redir_append(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "bye", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = ">>", .type = TOKEN_REDIR_APPEND};
+  static t_token_content token4 = {.value = "out.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"echo", "bye", NULL};
   static t_redir redir = {.type = REDIR_APPEND,
                           .from =
@@ -102,12 +127,23 @@ t_testdata redir_append(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo bye >> out.txt",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = "out.txt"};
 }
 
 t_testdata redir_mix(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "<", .type = TOKEN_REDIR_INPUT};
+  static t_token_content token3 = {.value = "out.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token4 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
+  static t_token_content token5 = {.value = "new.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv[] = {"cat", NULL};
   static t_redir redir1 = {.type = REDIR_INPUT,
                            .from =
@@ -152,12 +188,25 @@ t_testdata redir_mix(void) {
   };
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "cat < out.txt > new.txt",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = "new.txt"};
 }
 
 t_testdata pipe_to_redir(void) {
+  // TOKEN LIST
+  static t_token_content token1 = {.value = "echo", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token2 = {.value = "test", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token3 = {.value = "|", .type = TOKEN_PIPE};
+  static t_token_content token4 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
+  static t_token_content token5 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
+  static t_token_content token6 = {.value = "result.txt", .type = TOKEN_UNQUOTED_WORD};
+  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
+  static t_list token_list1 = {.content = (void *)&token1, .next = &token_list2};
   static char *argv1[] = {"echo", "test", NULL};
   static char *argv2[] = {"cat", NULL};
   static t_redir redir2 = {.type = REDIR_OUTPUT,
@@ -189,7 +238,7 @@ t_testdata pipe_to_redir(void) {
   static t_and_or and_or = {.pipeline = &pipeline, .op_next = OP_NONE};
   static t_ast ast = {.content = (void *)&and_or, .next = NULL};
   return (t_testdata){.input = "echo test | cat > result.txt",
-                      .token_list = {0},
+                      .token_list = token_list1,
                       .ast = ast,
                       .output_file = "result.txt"};
 }


### PR DESCRIPTION
## Summary
- define token lists for basic command tests
- define token lists for builtin, pipe, quote and env, and redirect tests

## Testing
- `make test` *(fails: unknown type name 't_data' during build)*

------
https://chatgpt.com/codex/tasks/task_e_684b7b0414388329ae80f544c07f8390