### PR TITLE
Add token list assertion helper

### DIFF
--- a/testdata/assert/token.c
+++ b/testdata/assert/token.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <string.h>
+#include "token.h"
+#include "libft.h"
+
+static void assert_single_token(t_token_content *expected, t_token_content *actual)
+{
+    assert(expected != NULL && actual != NULL);
+    assert(expected->type == actual->type);
+    assert(strcmp(expected->value, actual->value) == 0);
+}
+
+void assert_token_list(t_list *expected, t_list *actual)
+{
+    t_list *e_cur = expected;
+    t_list *a_cur = actual;
+
+    while (e_cur && a_cur)
+    {
+        t_token_content *e_token = (t_token_content *)e_cur->content;
+        t_token_content *a_token = (t_token_content *)a_cur->content;
+        assert_single_token(e_token, a_token);
+        e_cur = e_cur->next;
+        a_cur = a_cur->next;
+    }
+    assert(e_cur == NULL && a_cur == NULL);
+}

--- a/testdata/testdata.h
+++ b/testdata/testdata.h
@@ -57,4 +57,7 @@ void print_and_or(t_and_or *and_or, int indent);
 void print_pipeline(t_pipeline *pipeline, int indent);
 void print_command(t_command *cmd, int indent);
 void print_redirection(t_list *redir_list, int indent);
+
+// assert functions
+void assert_token_list(t_list *expected, t_list *actual);
 #endif // !TESTDATA_H


### PR DESCRIPTION
## Summary
- add helper to compare token lists in `testdata/assert/token.c`
- expose assertion prototype via `testdata/testdata.h`

## Testing
- `make tokenizer_test` *(fails: unknown type name 't_data')*
- `make testdata` *(fails: missing object directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b850264048329b11fda682d1d89f7