### PR TITLE
Add EOF tokens to all test data

### DIFF
--- a/testdata/basic.c
+++ b/testdata/basic.c
@@ -7,7 +7,9 @@
 t_testdata ls(void) {
   // TOKEN LIST
   static t_token_content token = {.value = "ls", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list = {.content = (void *)&token, .next = NULL};
+  static t_token_content token_eof = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list_eof = {.content = (void *)&token_eof, .next = NULL};
+  static t_list token_list = {.content = (void *)&token, .next = &token_list_eof};
 
   // AST
   static char *argv[] = {"ls", NULL};
@@ -32,7 +34,9 @@ t_testdata echo_hello(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "hello",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
   // AST
@@ -59,7 +63,9 @@ t_testdata cat_nofile(void) {
   static t_token_content token1 = {.value = "cat", .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "nofile",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
   // AST

--- a/testdata/builtin.c
+++ b/testdata/builtin.c
@@ -4,7 +4,9 @@
 t_testdata pwd(void) {
   // TOKEN LIST
   static t_token_content token = {.value = "pwd", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list = {.content = (void *)&token, .next = NULL};
+  static t_token_content token_eof = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list_eof = {.content = (void *)&token_eof, .next = NULL};
+  static t_list token_list = {.content = (void *)&token, .next = &token_list_eof};
 
   // AST
   static char *argv[] = {"pwd", NULL};
@@ -28,7 +30,9 @@ t_testdata pwd(void) {
 t_testdata cd_noarg(void) {
   // TOKEN LIST
   static t_token_content token = {.value = "cd", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list = {.content = (void *)&token, .next = NULL};
+  static t_token_content token_eof = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list_eof = {.content = (void *)&token_eof, .next = NULL};
+  static t_list token_list = {.content = (void *)&token, .next = &token_list_eof};
 
   // AST
   static char *argv[] = {"cd", NULL};
@@ -53,7 +57,9 @@ t_testdata cd_non_existing_dir(void) {
   static t_token_content token1 = {.value = "cd", .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "non_existing_dir",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 
@@ -86,7 +92,9 @@ t_testdata export_two_vars(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token3 = {.value = "VAR2=world",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_token_content token4 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
   static t_list token_list2 = {.content = (void *)&token2,
                                .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
@@ -124,7 +132,9 @@ t_testdata unset_then_echo(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token5 = {.value = "$VAR1",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_token_content token6 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
   static t_list token_list4 = {.content = (void *)&token4,
                                .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
@@ -173,7 +183,9 @@ t_testdata exit_status_42(void) {
   static t_token_content token1 = {.value = "exit",
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "42", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 

--- a/testdata/pipe.c
+++ b/testdata/pipe.c
@@ -9,7 +9,9 @@ t_testdata ls_pipe_grep(void) {
   static t_token_content token3 = {.value = "grep",
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token4 = {.value = ".c", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_token_content token5 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
                                .next = &token_list4};
   static t_list token_list2 = {.content = (void *)&token2,
@@ -54,7 +56,9 @@ t_testdata cat_makefile_pipe_wc_l(void) {
   static t_token_content token3 = {.value = "|", .type = TOKEN_PIPE};
   static t_token_content token4 = {.value = "wc", .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token5 = {.value = "-l", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_token_content token6 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
   static t_list token_list4 = {.content = (void *)&token4,
                                .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
@@ -104,7 +108,9 @@ t_testdata ls_pipe_grep_pipe_wc(void) {
   static t_token_content token5 = {.value = "|", .type = TOKEN_PIPE};
   static t_token_content token6 = {.value = "wc", .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token7 = {.value = "-l", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list7 = {.content = (void *)&token7, .next = NULL};
+  static t_token_content token8 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list8 = {.content = (void *)&token8, .next = NULL};
+  static t_list token_list7 = {.content = (void *)&token7, .next = &token_list8};
   static t_list token_list6 = {.content = (void *)&token6,
                                .next = &token_list7};
   static t_list token_list5 = {.content = (void *)&token5,

--- a/testdata/quote_and_env.c
+++ b/testdata/quote_and_env.c
@@ -8,7 +8,9 @@ t_testdata echo_env_home(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "$HOME",
                                    .type = TOKEN_DOUBLE_QUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 
@@ -36,7 +38,9 @@ t_testdata echo_no_expand_home(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "$HOME",
                                    .type = TOKEN_SINGLE_QUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 
@@ -66,7 +70,9 @@ t_testdata echo_concat_user(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "hello'$USER'world",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 
@@ -100,7 +106,9 @@ t_testdata export_and_echo(void) {
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token5 = {.value = "$VAR",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_token_content token6 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
   static t_list token_list4 = {.content = (void *)&token4,
                                .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
@@ -146,7 +154,9 @@ t_testdata echo_status(void) {
   static t_token_content token1 = {.value = "echo",
                                    .type = TOKEN_UNQUOTED_WORD};
   static t_token_content token2 = {.value = "$?", .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list2 = {.content = (void *)&token2, .next = NULL};
+  static t_token_content token3 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_list token_list2 = {.content = (void *)&token2, .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
                                .next = &token_list2};
 

--- a/testdata/redirect.c
+++ b/testdata/redirect.c
@@ -13,7 +13,9 @@ t_testdata redir_output(void) {
   static t_token_content token3 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
   static t_token_content token4 = {.value = "out.txt",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_token_content token5 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
                                .next = &token_list4};
   static t_list token_list2 = {.content = (void *)&token2,
@@ -61,7 +63,9 @@ t_testdata redir_input(void) {
   static t_token_content token2 = {.value = "<", .type = TOKEN_REDIR_INPUT};
   static t_token_content token3 = {.value = "out.txt",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list3 = {.content = (void *)&token3, .next = NULL};
+  static t_token_content token4 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_list token_list3 = {.content = (void *)&token3, .next = &token_list4};
   static t_list token_list2 = {.content = (void *)&token2,
                                .next = &token_list3};
   static t_list token_list1 = {.content = (void *)&token1,
@@ -107,7 +111,9 @@ t_testdata redir_append(void) {
   static t_token_content token3 = {.value = ">>", .type = TOKEN_REDIR_APPEND};
   static t_token_content token4 = {.value = "out.txt",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list4 = {.content = (void *)&token4, .next = NULL};
+  static t_token_content token5 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_list token_list4 = {.content = (void *)&token4, .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
                                .next = &token_list4};
   static t_list token_list2 = {.content = (void *)&token2,
@@ -158,7 +164,9 @@ t_testdata redir_mix(void) {
   static t_token_content token4 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
   static t_token_content token5 = {.value = "new.txt",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list5 = {.content = (void *)&token5, .next = NULL};
+  static t_token_content token6 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_list token_list5 = {.content = (void *)&token5, .next = &token_list6};
   static t_list token_list4 = {.content = (void *)&token4,
                                .next = &token_list5};
   static t_list token_list3 = {.content = (void *)&token3,
@@ -229,7 +237,9 @@ t_testdata pipe_to_redir(void) {
   static t_token_content token5 = {.value = ">", .type = TOKEN_REDIR_OUTPUT};
   static t_token_content token6 = {.value = "result.txt",
                                    .type = TOKEN_UNQUOTED_WORD};
-  static t_list token_list6 = {.content = (void *)&token6, .next = NULL};
+  static t_token_content token7 = {.value = "", .type = TOKEN_EOF};
+  static t_list token_list7 = {.content = (void *)&token7, .next = NULL};
+  static t_list token_list6 = {.content = (void *)&token6, .next = &token_list7};
   static t_list token_list5 = {.content = (void *)&token5,
                                .next = &token_list6};
   static t_list token_list4 = {.content = (void *)&token4,


### PR DESCRIPTION
## Summary
- append EOF tokens to token lists for each test case

## Testing
- `make testdata CFLAGS="-Itestdata -Isrc -Ilibft -Wall -Wextra -Werror"`
- `make testdata_clean`

------
https://chatgpt.com/codex/tasks/task_e_684b96b7e8508329b43208a5c19d4a98